### PR TITLE
Fix word capitalization by using codepoints

### DIFF
--- a/jacow.typ
+++ b/jacow.typ
@@ -133,7 +133,7 @@
       words += txt.matches(regex("()(\\w{4,})")) // words with 4+ letters
       for m in words {
         let (pre, word) = m.captures
-        word = upper(word.at(0)) + word.slice(1)
+        word = upper(word.codepoints().at(0)) + word.codepoints().slice(1).join("")
         txt = txt.slice(0, m.start) + pre + word + txt.slice(m.end)
       }
       txt

--- a/jacow.typ
+++ b/jacow.typ
@@ -133,7 +133,9 @@
       words += txt.matches(regex("()(\\w{4,})")) // words with 4+ letters
       for m in words {
         let (pre, word) = m.captures
-        word = upper(word.codepoints().at(0)) + word.codepoints().slice(1).join("")
+        word = (
+          upper(word.codepoints().at(0)) + word.codepoints().slice(1).join("")
+        )
         txt = txt.slice(0, m.start) + pre + word + txt.slice(m.end)
       }
       txt


### PR DESCRIPTION
#### Minimal reproducible example
```typst
#import "@preview/accelerated-jacow:0.14.0": jacow

#show: jacow.with(
  abstract-title: "Абв", // Cyrillic letters
  abstract: [/* ... */],
)
```

Results in `string index 1 is not a character boundary` error.